### PR TITLE
feat(swagger): introduce @spectrajs/swagger package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1706,6 +1706,10 @@
       "resolved": "packages/node",
       "link": true
     },
+    "node_modules/@spectrajs/swagger": {
+      "resolved": "packages/swagger",
+      "link": true
+    },
     "node_modules/@spectrajs/trpc": {
       "resolved": "packages/trpc",
       "link": true
@@ -6497,7 +6501,7 @@
     },
     "packages/core": {
       "name": "@spectrajs/core",
-      "version": "0.6.2",
+      "version": "0.7.1",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.15.0",
@@ -6510,7 +6514,7 @@
     },
     "packages/node": {
       "name": "@spectrajs/node",
-      "version": "0.6.2",
+      "version": "0.7.1",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.15.0",
@@ -6523,13 +6527,30 @@
         "typescript": "^5.6.3"
       }
     },
-    "packages/trpc": {
-      "name": "@spectrajs/trpc",
-      "version": "0.6.2",
+    "packages/swagger": {
+      "name": "@spectrajs/swagger",
+      "version": "0.0.0",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.15.0",
-        "@spectrajs/core": "^0.6.2",
+        "@spectrajs/core": "^0.7.1",
+        "@types/node": "^22.10.2",
+        "eslint": "^9.15.0",
+        "prettier": "^3.3.3",
+        "tsup": "^8.3.5",
+        "typescript": "^5.6.3"
+      },
+      "peerDependencies": {
+        "@spectrajs/core": ">= 0.7.1"
+      }
+    },
+    "packages/trpc": {
+      "name": "@spectrajs/trpc",
+      "version": "0.7.1",
+      "license": "MIT",
+      "devDependencies": {
+        "@eslint/js": "^9.15.0",
+        "@spectrajs/core": "^0.7.1",
         "@trpc/server": "^10.45.2",
         "@types/node": "^22.10.2",
         "eslint": "^9.15.0",

--- a/packages/swagger/README.md
+++ b/packages/swagger/README.md
@@ -1,0 +1,32 @@
+<div align="center">
+<h1>
+  Spectra
+</h1>
+<p>
+  Fast, lightweight and fully typesafe web framework
+</p>
+
+</div>
+
+# `@spectrajs/swagger`
+
+`@spectrajs/swagger` provides [Swagger](https://swagger.io/) integration for Spectra.
+
+> [!WARNING]
+> This package is still in development and is not ready for production use.
+
+## Installation
+
+```bash
+# npm
+npm install @spectrajs/swagger
+
+# yarn
+yarn add @spectrajs/swagger
+
+# pnpm
+pnpm add @spectrajs/swagger
+
+# bun
+bun add @spectrajs/swagger
+```

--- a/packages/swagger/package.json
+++ b/packages/swagger/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@spectrajs/swagger",
+  "version": "0.0.0",
+  "description": "Swagger integration for Spectra",
+  "main": "./dist/index.cjs",
+  "type": "module",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "scripts": {
+    "build": "tsup",
+    "lint": "eslint src",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/metebykl/spectra.git"
+  },
+  "keywords": [
+    "web",
+    "http",
+    "framework",
+    "adapter"
+  ],
+  "author": "metebykl",
+  "license": "MIT",
+  "homepage": "https://github.com/metebykl/spectra#readme",
+  "files": [
+    "dist"
+  ],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "peerDependencies": {
+    "@spectrajs/core": ">= 0.7.1"
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.15.0",
+    "@spectrajs/core": "^0.7.1",
+    "@types/node": "^22.10.2",
+    "eslint": "^9.15.0",
+    "prettier": "^3.3.3",
+    "tsup": "^8.3.5",
+    "typescript": "^5.6.3"
+  }
+}

--- a/packages/swagger/src/index.ts
+++ b/packages/swagger/src/index.ts
@@ -1,5 +1,6 @@
-import type { MiddlewareHandler } from "@spectrajs/core";
-import type { OpenAPIOperation } from "./openapi";
+import type { Spectra, MiddlewareHandler } from "@spectrajs/core";
+import type { OpenAPIDocument, OpenAPIOperation } from "./openapi";
+import { toOpenAPIPath } from "./utils";
 
 const schemaSymbol = Symbol("openapi");
 
@@ -8,6 +9,43 @@ export const addToDocs = (schema: OpenAPIOperation): MiddlewareHandler => {
     await next();
   };
 
-  Object.defineProperty(mw, schemaSymbol, schema);
+  Object.assign(mw, { [schemaSymbol]: schema });
   return mw;
+};
+
+export type GenerateSpecsOptions = {
+  documentation?: Partial<OpenAPIDocument>;
+};
+
+export const generateSpecs = (
+  app: Spectra,
+  opts?: GenerateSpecsOptions
+): OpenAPIDocument => {
+  const documentation = opts?.documentation;
+
+  const schema: OpenAPIDocument["paths"] = {};
+
+  for (const route of app.routes) {
+    if (!(schemaSymbol in route.handler)) continue;
+
+    const path = toOpenAPIPath(route.path);
+    const method = route.method.toLowerCase();
+    const docs = route.handler[schemaSymbol] as OpenAPIOperation;
+
+    schema[path] = {
+      ...(schema[path] ?? {}),
+      [method]: docs,
+    };
+  }
+
+  return {
+    ...documentation,
+    openapi: documentation?.openapi ?? "3.0.3",
+    info: {
+      title: "Spectra Documentation",
+      version: "0.0.0",
+      ...documentation?.info,
+    },
+    paths: schema,
+  };
 };

--- a/packages/swagger/src/index.ts
+++ b/packages/swagger/src/index.ts
@@ -13,13 +13,25 @@ export const addToDocs = (schema: OpenAPIOperation): MiddlewareHandler => {
   return mw;
 };
 
-export type GenerateSpecsOptions = {
+export type OpenAPISpecsOptions = {
   documentation?: Partial<OpenAPIDocument>;
+};
+
+export const openAPISpecs = (
+  app: Spectra,
+  opts?: OpenAPISpecsOptions
+): MiddlewareHandler => {
+  let specs: OpenAPIDocument | null = null;
+  return async function (c) {
+    if (specs) return c.json(specs);
+    specs = await generateSpecs(app, opts);
+    return c.json(specs);
+  };
 };
 
 export const generateSpecs = (
   app: Spectra,
-  opts?: GenerateSpecsOptions
+  opts?: OpenAPISpecsOptions
 ): OpenAPIDocument => {
   const documentation = opts?.documentation;
 

--- a/packages/swagger/src/index.ts
+++ b/packages/swagger/src/index.ts
@@ -4,7 +4,7 @@ import { toOpenAPIPath } from "./utils";
 
 const schemaSymbol = Symbol("openapi");
 
-export const addToDocs = (schema: OpenAPIOperation): MiddlewareHandler => {
+export const describeRoute = (schema: OpenAPIOperation): MiddlewareHandler => {
   const mw: MiddlewareHandler = async (_, next) => {
     await next();
   };

--- a/packages/swagger/src/index.ts
+++ b/packages/swagger/src/index.ts
@@ -49,3 +49,43 @@ export const generateSpecs = (
     paths: schema,
   };
 };
+
+interface SwaggerUIOptions {
+  url: string;
+  title?: string;
+  version?: string;
+}
+
+export const swaggerUI = ({
+  url,
+  title = "SwaggerUI",
+  version = "5.18.2",
+}: SwaggerUIOptions): MiddlewareHandler => {
+  return async function (c) {
+    return c.html(`
+      <!doctype html>
+      <html lang="en">
+        <head>
+          <meta charset="UTF-8" />
+          <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+          <title>${title}</title>
+          <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swagger-ui-dist@${version}/swagger-ui.css" />
+        </head>
+        <body>
+          <div>
+            <div id="swagger-ui"></div>
+            <script src="https://cdn.jsdelivr.net/npm/swagger-ui-dist@${version}/swagger-ui-bundle.js" crossorigin="anonymous"></script>
+            <script>
+              window.onload = () => {
+                window.ui = SwaggerUIBundle({
+                  url: '${url}',
+                  dom_id: '#swagger-ui'
+                });
+              };
+            </script>
+          </div>
+        </body>
+      </html>
+      `);
+  };
+};

--- a/packages/swagger/src/index.ts
+++ b/packages/swagger/src/index.ts
@@ -1,0 +1,13 @@
+import type { MiddlewareHandler } from "@spectrajs/core";
+import type { OpenAPIOperation } from "./openapi";
+
+const schemaSymbol = Symbol("openapi");
+
+export const addToDocs = (schema: OpenAPIOperation): MiddlewareHandler => {
+  const mw: MiddlewareHandler = async (_, next) => {
+    await next();
+  };
+
+  Object.defineProperty(mw, schemaSymbol, schema);
+  return mw;
+};

--- a/packages/swagger/src/openapi.ts
+++ b/packages/swagger/src/openapi.ts
@@ -1,0 +1,187 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export interface OpenAPISchema {
+  openapi: string;
+  info: OpenAPIInfo;
+  servers?: OpenAPIServer[];
+  paths: Record<string, OpenAPIPathItem>;
+  components?: OpenAPIComponents;
+  security?: OpenAPISecurityRequirement[];
+  tags?: OpenAPITag[];
+  externalDocs?: OpenAPIExternalDocumentation;
+}
+
+export type OpenAPIInfo = {
+  title: string;
+  version: string;
+  description?: string;
+  termsOfService?: string;
+  contact?: OpenAPIContact;
+  license?: OpenAPILicense;
+};
+
+export type OpenAPIContact = {
+  name?: string;
+  url?: string;
+  email?: string;
+};
+
+export type OpenAPILicense = {
+  name: string;
+  url?: string;
+};
+
+export type OpenAPITag = {
+  name: string;
+  description?: string;
+  externalDocs?: OpenAPIExternalDocumentation;
+};
+
+export type OpenAPIComponents = {
+  schemas?: Record<string, OpenAPISchemaObject>;
+  responses?: Record<string, OpenAPIResponse>;
+  parameters?: Record<string, OpenAPIParameter>;
+  examples?: Record<string, OpenAPIExample>;
+  requestBodies?: Record<string, OpenAPIRequestBody>;
+  headers?: Record<string, OpenAPIHeader>;
+  securitySchemes?: Record<string, any>;
+  links?: Record<string, OpenAPILink>;
+  callbacks?: Record<string, string>;
+};
+
+export type OpenAPIPathItem = {
+  summary?: string;
+  description?: string;
+} & Record<string, OpenAPIOperation>;
+
+export type OpenAPIOperation = {
+  summary?: string;
+  description?: string;
+  tags?: string[];
+  responses: OpenAPIResponses;
+  operationId?: string;
+  parameters?: OpenAPIParameter[];
+  requestBody?: OpenAPIRequestBody;
+  callbacks?: Record<string, OpenAPIPathItem>;
+  deprecated?: boolean;
+  security?: OpenAPISecurityRequirement[];
+  servers?: OpenAPIServer[];
+};
+
+export type OpenAPIResponses = Record<number, OpenAPIResponse>;
+
+export type OpenAPIResponse = {
+  description: string;
+  headers?: Record<string, OpenAPIHeader>;
+  content?: Record<string, OpenAPIMediaType>;
+  links?: Record<string, OpenAPILink>;
+};
+
+export type OpenAPIHeader = {
+  description?: string;
+  required?: boolean;
+  deprecated?: boolean;
+  allowEmptyValue?: boolean;
+  style?: string;
+  explode?: boolean;
+  allowReserved?: boolean;
+  schema?: OpenAPISchemaObject;
+  example?: any;
+  examples?: Record<string, OpenAPIExample>;
+  content?: Record<string, OpenAPIMediaType>;
+};
+
+export type OpenAPIMediaType = {
+  schema?: OpenAPISchema;
+  example?: any;
+  examples?: Record<string, OpenAPIExample>;
+  encoding?: Record<string, OpenAPIEncoding>;
+};
+
+export type OpenAPISchemaObject = {
+  nullable?: boolean;
+  discriminator?: OpenAPIDiscriminator;
+  readOnly?: boolean;
+  writeOnly?: boolean;
+  xml?: OpenAPIXMLObject;
+  externalDocs?: OpenAPIExternalDocumentation;
+  example?: any;
+  deprecated?: boolean;
+};
+
+export type OpenAPIParameter = {
+  name: string;
+  in: "query" | "header" | "path" | "cookie";
+  description?: string;
+  required?: boolean;
+  deprecated?: boolean;
+  allowEmptyValue?: boolean;
+  style?: string;
+  explode?: boolean;
+  allowReserved?: boolean;
+  schema?: OpenAPISchema;
+  example?: any;
+  examples?: Record<string, OpenAPIExample>;
+  content?: Record<string, OpenAPIMediaType>;
+};
+
+export type OpenAPIExample = {
+  summary?: string;
+  description?: string;
+  value?: any;
+  externalValue?: string;
+};
+
+export type OpenAPIEncoding = {
+  contentType?: string;
+  headers?: Record<string, OpenAPIHeader>;
+  style?: string;
+  explode?: boolean;
+  allowReserved?: boolean;
+};
+
+export type OpenAPIDiscriminator = {
+  propertyName: string;
+  mapping?: Record<string, string>;
+};
+
+export type OpenAPIXMLObject = {
+  name?: string;
+  namespace?: string;
+  prefix?: string;
+  attribute?: string;
+  wrapped?: boolean;
+};
+
+export type OpenAPIExternalDocumentation = {
+  url: string;
+  description?: string;
+};
+
+export type OpenAPIRequestBody = {
+  content: Record<string, OpenAPIMediaType>;
+  description?: string;
+  required?: boolean;
+};
+
+export type OpenAPIServer = {
+  url: string;
+  description?: string;
+  variables?: Record<string, OpenAPIServerVariable>;
+};
+
+export type OpenAPIServerVariable = {
+  default?: string;
+  description?: string;
+  enum?: string[];
+};
+
+export type OpenAPISecurityRequirement = Record<string, string[]>;
+
+export type OpenAPILink = {
+  operationRef?: string;
+  operationId?: string;
+  parameters?: Record<string, any>;
+  requestBody?: any;
+  description?: string;
+  server?: OpenAPIServer;
+};

--- a/packages/swagger/src/openapi.ts
+++ b/packages/swagger/src/openapi.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-export interface OpenAPISchema {
+export interface OpenAPIDocument {
   openapi: string;
   info: OpenAPIInfo;
   servers?: OpenAPIServer[];
@@ -91,7 +91,7 @@ export type OpenAPIHeader = {
 };
 
 export type OpenAPIMediaType = {
-  schema?: OpenAPISchema;
+  schema?: OpenAPISchemaObject;
   example?: any;
   examples?: Record<string, OpenAPIExample>;
   encoding?: Record<string, OpenAPIEncoding>;
@@ -118,7 +118,7 @@ export type OpenAPIParameter = {
   style?: string;
   explode?: boolean;
   allowReserved?: boolean;
-  schema?: OpenAPISchema;
+  schema?: OpenAPISchemaObject;
   example?: any;
   examples?: Record<string, OpenAPIExample>;
   content?: Record<string, OpenAPIMediaType>;

--- a/packages/swagger/src/utils.ts
+++ b/packages/swagger/src/utils.ts
@@ -1,0 +1,23 @@
+export const ALLOWED_METHODS = [
+  "GET",
+  "PUT",
+  "POST",
+  "PATCH",
+  "DELETE",
+  "OPTIONS",
+  "HEAD",
+  "TRACE",
+] as const;
+
+export const toOpenAPIPath = (path: string): string => {
+  return path
+    .split("/")
+    .map((p) => {
+      let t = p;
+      if (t.startsWith(":")) {
+        t = `{${t.slice(1, t.length)}}`;
+      }
+      return t;
+    })
+    .join("/");
+};

--- a/packages/swagger/test/index.test.ts
+++ b/packages/swagger/test/index.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect } from "vitest";
 import { Spectra } from "@spectrajs/core";
-import { addToDocs, generateSpecs, swaggerUI } from "../src";
+import { describeRoute, generateSpecs, swaggerUI } from "../src";
 
 const req = (path: string) => new Request(`http://localhost${path}`);
 
@@ -11,7 +11,7 @@ describe("OpenAPI", () => {
 
       app.get(
         "/api/users/:userId",
-        addToDocs({
+        describeRoute({
           description: "Get user information",
           parameters: [
             {

--- a/packages/swagger/test/index.test.ts
+++ b/packages/swagger/test/index.test.ts
@@ -1,6 +1,108 @@
-import { describe, test } from "vitest";
+import { describe, test, expect } from "vitest";
+import { Spectra } from "@spectrajs/core";
+import { addToDocs, generateSpecs, swaggerUI } from "../src";
 
-describe("Swagger", () => {
-  // TODO: add tests
-  test("");
+const req = (path: string) => new Request(`http://localhost${path}`);
+
+describe("OpenAPI", () => {
+  describe("generateSpecs", () => {
+    test("Example app", () => {
+      const app = new Spectra();
+
+      app.get(
+        "/api/users/:userId",
+        addToDocs({
+          description: "Get user information",
+          parameters: [
+            {
+              name: "userId",
+              in: "path",
+              schema: {},
+              required: true,
+            },
+          ],
+          responses: { 200: { description: "Success" } },
+          tags: ["users"],
+        }),
+        (c) => c.json({ userId: c.req.param("userId") })
+      );
+
+      const specs = generateSpecs(app);
+
+      expect(specs.openapi).toBe("3.0.3");
+      expect(specs.info).toEqual({
+        title: "Spectra Documentation",
+        version: "0.0.0",
+      });
+      expect(specs.paths).toEqual({
+        "/api/users/{userId}": {
+          get: {
+            description: "Get user information",
+            parameters: [
+              {
+                name: "userId",
+                in: "path",
+                schema: {},
+                required: true,
+              },
+            ],
+            responses: { 200: { description: "Success" } },
+            tags: ["users"],
+          },
+        },
+      });
+    });
+  });
+});
+
+describe("SwaggerUI Middleware", async () => {
+  test("Basic", async () => {
+    const app = new Spectra();
+    app.use(
+      "/swagger",
+      swaggerUI({ url: "https://petstore3.swagger.io/api/v3/openapi.json" })
+    );
+
+    const res = await app.fetch(req("/swagger"));
+    expect(res.headers.get("Content-Type")).toBe("text/html; charset=UTF-8");
+    expect(res.status).toBe(200);
+  });
+
+  test("Custom title", async () => {
+    const app = new Spectra();
+    app.use(
+      "/swagger",
+      swaggerUI({
+        title: "Documentation",
+        url: "https://petstore3.swagger.io/api/v3/openapi.json",
+      })
+    );
+
+    const res = await app.fetch(req("/swagger"));
+    expect(res.status).toBe(200);
+
+    const html = await res.text();
+    expect(html.includes("<title>Documentation</title>")).toBe(true);
+  });
+
+  test("Custom version", async () => {
+    const app = new Spectra();
+    app.use(
+      "/swagger",
+      swaggerUI({
+        version: "5.17.0",
+        url: "https://petstore3.swagger.io/api/v3/openapi.json",
+      })
+    );
+
+    const res = await app.fetch(req("/swagger"));
+    expect(res.status).toBe(200);
+
+    const html = await res.text();
+    expect(
+      html.includes(
+        "https://cdn.jsdelivr.net/npm/swagger-ui-dist@5.17.0/swagger-ui-bundle.js"
+      )
+    ).toBe(true);
+  });
 });

--- a/packages/swagger/test/index.test.ts
+++ b/packages/swagger/test/index.test.ts
@@ -1,0 +1,6 @@
+import { describe, test } from "vitest";
+
+describe("Swagger", () => {
+  // TODO: add tests
+  test("");
+});

--- a/packages/swagger/test/utils.test.ts
+++ b/packages/swagger/test/utils.test.ts
@@ -1,0 +1,8 @@
+import { test, expect } from "vitest";
+import { toOpenAPIPath } from "../src/utils";
+
+test("toOpenAPIPath", () => {
+  const path = "/api/users/:userId";
+  const openAPIPath = toOpenAPIPath(path);
+  expect(openAPIPath).toBe("/api/users/{userId}");
+});

--- a/packages/swagger/tsconfig.json
+++ b/packages/swagger/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src", "test"]
+}

--- a/packages/swagger/tsup.config.ts
+++ b/packages/swagger/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm", "cjs"],
+  dts: true,
+  splitting: false,
+  sourcemap: false,
+  bundle: false,
+  clean: true,
+});

--- a/packages/swagger/tsup.config.ts
+++ b/packages/swagger/tsup.config.ts
@@ -6,6 +6,6 @@ export default defineConfig({
   dts: true,
   splitting: false,
   sourcemap: false,
-  bundle: false,
+  bundle: true,
   clean: true,
 });

--- a/packages/swagger/vitest.config.ts
+++ b/packages/swagger/vitest.config.ts
@@ -1,0 +1,1 @@
+export { default } from "../../vitest.config";


### PR DESCRIPTION
### New Features
Introducing `@spectrajs/swagger`, a plugin which provides **OpenAPI** and **SwaggerUI** integration:

- `describeRoute`: Add documentation for a route.
- `generateSpecs`: Generate OpenAPI document for a Spectra instance.
- `openAPISpecs`: A middleware that serves the generated OpenAPI document.
- `swaggerUI`: A middleware that serves a SwaggerUI client.