### PR TITLE
refactor(request): remove unnecessary `toLowerCase()` for `req.header()`

### DIFF
--- a/packages/core/src/request.test.ts
+++ b/packages/core/src/request.test.ts
@@ -17,6 +17,18 @@ describe("Headers", () => {
     request.headers.set("X-Test-Message", "Hello World!");
     app.fetch(request);
   });
+
+  test("Header name is case-insensitive", () => {
+    const request = new Request("http://localhost/", {
+      headers: {
+        "Content-Type": "text/plain",
+        lowercase: "value",
+      },
+    });
+    const req = new SpectraRequest(request, {});
+    expect(req.header("Content-Type")).toBe("text/plain");
+    expect(req.header("LowerCase")).toBe("value");
+  });
 });
 
 describe("Path parameters", () => {

--- a/packages/core/src/request.ts
+++ b/packages/core/src/request.ts
@@ -45,8 +45,7 @@ export class SpectraRequest<P extends string = "/"> {
   }
 
   header(name: IncomingHttpHeaders | (string & {})): string | undefined {
-    const key = name.toLowerCase();
-    return this.raw.headers.get(key) ?? undefined;
+    return this.raw.headers.get(name) ?? undefined;
   }
 
   async #parseBody(key: keyof Body) {


### PR DESCRIPTION
`Headers.get()` is **case-insensitive**. So, the `toLowerCase()` is unnecessary.
https://developer.mozilla.org/en-US/docs/Web/API/Headers/get#syntax