### PR TITLE
fix(request): update return type of query and queries to include undefined in record values

### DIFF
--- a/.changeset/three-queens-thank.md
+++ b/.changeset/three-queens-thank.md
@@ -1,0 +1,5 @@
+---
+"@spectrajs/core": patch
+---
+
+Update return type of `query` and `queries` to include `undefined` in record values

--- a/packages/core/src/request.ts
+++ b/packages/core/src/request.ts
@@ -33,13 +33,13 @@ export class SpectraRequest<P extends string = "/"> {
   }
 
   query(key: string): string | undefined;
-  query(): Record<string, string>;
+  query(): Record<string, string | undefined>;
   query(key?: string) {
     return getQueryParam(this.raw.url, key);
   }
 
   queries(key: string): string[] | undefined;
-  queries(): Record<string, string[]>;
+  queries(): Record<string, string[] | undefined>;
   queries(key?: string) {
     return getQueryParam(this.raw.url, key, true);
   }

--- a/packages/core/src/utils/url.ts
+++ b/packages/core/src/utils/url.ts
@@ -92,10 +92,10 @@ export const getQueryParam = (
   multiple?: boolean
 ):
   | string
-  | undefined
   | string[]
-  | Record<string, string>
-  | Record<string, string[]> => {
+  | undefined
+  | Record<string, string | undefined>
+  | Record<string, string[] | undefined> => {
   let encoded;
 
   if (!multiple && key && !/[%+]/.test(key)) {


### PR DESCRIPTION
Return type of `query()` and `queries()` methods was updated to reflect that values in the returned record can be `undefined`. This PR ensures that the type definitions accurately represent possible return values when query parameters are not present.