### PR TITLE
feat(validator): introduce validator

### DIFF
--- a/.changeset/poor-readers-write.md
+++ b/.changeset/poor-readers-write.md
@@ -1,0 +1,5 @@
+---
+"@spectrajs/core": minor
+---
+
+Added built-in request validator.

--- a/docs/guides/validation.md
+++ b/docs/guides/validation.md
@@ -1,0 +1,46 @@
+<h1 align="center">Spectra</h1>
+
+## Validation
+
+Spectra offers a simple yet powerful validation system that ensures
+incoming data is valid, secure, and properly formatted before processing.
+
+### Core Validator
+
+The Core Validator is the foundation of **Spectra**’s validation system.
+It allows you to manually validate data efficiently, without
+relying on third-party libraries.
+
+Start by importing `validator` from `@spectrajs/core/validator`:
+
+```ts
+import { validator } from "@spectrajs/core/validator";
+```
+
+To validate data, specify your `target` as the first argument
+and a validation callback as the second argument. In the callback,
+validate data and return the validated values at the end.
+
+```ts
+app.post(
+  "/greet",
+  validator("json", (value, c) => {
+    const name = value["name"];
+    if (!name || typeof name !== "string") {
+      return c.text("Invalid Name", 400);
+    }
+    return {
+      name,
+    };
+  }),
+  (c) => {
+    const { name } = c.get<{ name: string }>("valid");
+    return c.json({ message: `Hi ${name}!` });
+  }
+);
+```
+
+The validated values are stored in `c.get("valid")` and can be safely
+accessed in the next middleware.
+
+Validation targets include `json`, `form`, `query`, `params`, and `headers`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,6 +19,7 @@
 ### Guides
 
 - [Testing](guides/testing.md)
+- [Validation](guides/validation.md)
 
 ### Plugins
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -34,6 +34,11 @@
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     },
+    "./validator": {
+      "types": "./dist/validator.d.ts",
+      "import": "./dist/validator.js",
+      "require": "./dist/validator.cjs"
+    },
     "./cookie": {
       "types": "./dist/cookie.d.ts",
       "import": "./dist/cookie.js",

--- a/packages/core/src/validator.test.ts
+++ b/packages/core/src/validator.test.ts
@@ -1,0 +1,245 @@
+import { describe, test, expect } from "vitest";
+import { Spectra } from "./spectra";
+import { validator } from "./validator";
+
+describe("JSON", () => {
+  const app = new Spectra();
+  app.post(
+    "/greet",
+    validator("json", (value, c) => {
+      const name = value["name"];
+      if (!name || typeof name !== "string") {
+        return c.text("Bad Request", 400);
+      }
+      return { name };
+    }),
+    (c) => {
+      const { name } = c.get("valid") as { name: string };
+      return c.json({ message: `Hi ${name}!` });
+    }
+  );
+
+  test("Should return response 200 with valid data", async () => {
+    const res = await app.fetch(
+      new Request("http://localhost/greet", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ name: "Spectra" }),
+      })
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ message: "Hi Spectra!" });
+  });
+
+  test("Should return response 400", async () => {
+    const res = await app.fetch(
+      new Request("http://localhost/greet", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ name: 1 }),
+      })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  test("Should return response 400", async () => {
+    const res = await app.fetch(
+      new Request("http://localhost/greet", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ foo: "bar" }),
+      })
+    );
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("Malformed JSON request", () => {
+  const app = new Spectra();
+  app.post(
+    "/post",
+    validator("json", (value) => value),
+    (c) => {
+      return c.json(c.get("valid"));
+    }
+  );
+
+  test("Should return response 400 if body is not a valid JSON", async () => {
+    const res = await app.fetch(
+      new Request("http://localhost/post", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: `{"foo": "bar}`,
+      })
+    );
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("FormData", () => {
+  const app = new Spectra();
+  app.post(
+    "/greet",
+    validator("form", (value, c) => {
+      const name = value.get("name");
+      if (!name || typeof name !== "string") {
+        return c.text("Bad Request", 400);
+      }
+      return value;
+    }),
+    (c) => {
+      const formData = c.get("valid") as FormData;
+      return c.text(`Hi ${formData.get("name")}!`);
+    }
+  );
+
+  test("Should return response 200 with valid data", async () => {
+    const formData = new FormData();
+    formData.append("name", "Spectra");
+    const res = await app.fetch(
+      new Request("http://localhost/greet", {
+        method: "POST",
+        body: formData,
+      })
+    );
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("Hi Spectra!");
+  });
+
+  test("Should return response 400", async () => {
+    const formData = new FormData();
+    formData.append("foo", "bar");
+    const res = await app.fetch(
+      new Request("http://localhost/greet", {
+        method: "POST",
+        body: formData,
+      })
+    );
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("Malformed FormData request", () => {
+  const app = new Spectra();
+  app.post(
+    "/post",
+    validator("form", (value) => value),
+    (c) => {
+      return c.json(c.get("valid"));
+    }
+  );
+
+  test("Should return response 400 for malformed content type", async () => {
+    const res = await app.fetch(
+      new Request("http://localhost/post", {
+        method: "POST",
+        headers: {
+          "Content-Type": "multipart/form-data",
+        },
+        body: "foo",
+      })
+    );
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("Query", () => {
+  const app = new Spectra();
+  app.get(
+    "/search",
+    validator("query", (value, c) => {
+      const q = value["q"];
+      if (!q) {
+        return c.text("Bad Request", 400);
+      }
+      return { q };
+    }),
+    (c) => {
+      const { q } = c.get("valid") as { q: string };
+      return c.text(q);
+    }
+  );
+
+  test("Should return response 200 with valid data", async () => {
+    const res = await app.fetch(new Request("http://localhost/search?q=foo"));
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("foo");
+  });
+
+  test("Should return response 400", async () => {
+    const res = await app.fetch(new Request("http://localhost/search?foo=bar"));
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("Params", () => {
+  const app = new Spectra();
+  app.get(
+    "/posts/:id",
+    validator("params", (value, c) => {
+      const id = value["id"];
+      if (!id || !id.startsWith("ab")) {
+        return c.text("Invalid Id", 400);
+      }
+      return { id };
+    }),
+    (c) => {
+      const { id } = c.get("valid") as { id: string };
+      return c.text(id);
+    }
+  );
+
+  test("Should return response 200 with valid data", async () => {
+    const res = await app.fetch(new Request("http://localhost/posts/abCdE"));
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("abCdE");
+  });
+
+  test("Should return response 400", async () => {
+    const res = await app.fetch(new Request("http://localhost/posts/foo"));
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("Headers", () => {
+  const app = new Spectra();
+  app.get(
+    "/",
+    validator("headers", (value, c) => {
+      const reqId = value["x-request-id"];
+      if (!reqId) {
+        return c.text("Bad Request", 400);
+      }
+      return { reqId };
+    }),
+    (c) => {
+      const { reqId } = c.get("valid") as { reqId: string };
+      return c.text(reqId);
+    }
+  );
+
+  test("Should return response 200 with valid data", async () => {
+    const res = await app.fetch(
+      new Request("http://localhost/", {
+        headers: {
+          "X-Request-Id": "1",
+        },
+      })
+    );
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("1");
+  });
+
+  test("Should return response 400", async () => {
+    const res = await app.fetch(new Request("http://localhost/"));
+    expect(res.status).toBe(400);
+  });
+});

--- a/packages/core/src/validator.ts
+++ b/packages/core/src/validator.ts
@@ -1,0 +1,61 @@
+import type { Context } from "./context";
+import type { MiddlewareHandler } from "./types";
+import type { RequestHeader } from "./utils/headers";
+
+export type ValidationTargets = {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  json: any;
+  form: FormData;
+  query: Record<string, string | string[]>;
+  params: Record<string, string>;
+  headers: Record<RequestHeader | (string & {}), string>;
+};
+
+export type ValidationFunction<I, O> = (
+  value: I,
+  c: Context
+) => O | Response | Promise<O> | Promise<Response>;
+
+export const validator = <U extends keyof ValidationTargets, O>(
+  target: U,
+  validationFn: ValidationFunction<ValidationTargets[U], O>
+): MiddlewareHandler => {
+  return async function (c, next) {
+    let value;
+
+    // TODO: check content-type for json and form targets
+    switch (target) {
+      case "json":
+        try {
+          value = await c.req.json();
+        } catch {
+          return c.text("Bad Request", 400);
+        }
+        break;
+      case "form":
+        try {
+          value = await c.req.formData();
+        } catch {
+          return c.text("Bad Request", 400);
+        }
+        break;
+      case "query":
+        value = c.req.queries();
+        break;
+      case "params":
+        value = c.req.params();
+        break;
+      case "headers":
+        value = c.req.header();
+        break;
+    }
+
+    const res = await validationFn(value, c);
+    if (res instanceof Response) {
+      return res;
+    }
+
+    c.set("valid", res);
+    await next();
+  };
+};


### PR DESCRIPTION
This PR introduces a request validator.

Example usage:
```ts
app.post(
  "/greet",
  validator("json", (value, c) => {
    const name = value["name"];
    if (!name || typeof name !== "string") {
      return c.text("Bad Request", 400);
    }

    return {
      name,
    };
  }),
  (c) => {
    const { name } = c.get("valid") as { name: string };
    return c.json({ message: `Hi ${name}!` });
  }
);
```