### PR TITLE
feat(validator): migrate validation interface to c.req.valid(target)

### DIFF
--- a/.changeset/shy-singers-allow.md
+++ b/.changeset/shy-singers-allow.md
@@ -1,0 +1,6 @@
+---
+"@spectrajs/core": minor
+"@spectrajs/zod": minor
+---
+
+Migrated validation interface from `c.get("valid")` to `c.req.valid(target)`.

--- a/docs/guides/validation.md
+++ b/docs/guides/validation.md
@@ -34,13 +34,13 @@ app.post(
     };
   }),
   (c) => {
-    const { name } = c.get<{ name: string }>("valid");
+    const { name } = c.req.valid<{ name: string }>("json");
     return c.json({ message: `Hi ${name}!` });
   }
 );
 ```
 
-The validated values are stored in `c.get("valid")` and can be safely
+The validated values are stored in `c.req.valid(target)` and can be safely
 accessed in the next middleware.
 
 Validation targets include `json`, `form`, `query`, `params`, and `headers`.
@@ -76,7 +76,7 @@ Finally, use `zodValidator` to validate incoming data:
 
 ```ts
 app.post("/post", zodValidator("json", schema), async (c) => {
-  const { name, age } = c.get<z.infer<typeof schema>>("valid");
+  const { name, age } = c.req.valid<z.infer<typeof schema>>("json");
   return c.json({ name, age });
 });
 ```

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,7 +3,13 @@ import { Spectra } from "./spectra";
 /**
  * Types for handlers, middleware handlers, error handlers, and more.
  */
-export type { Handler, MiddlewareHandler, Next, ErrorHandler } from "./types";
+export type {
+  Handler,
+  MiddlewareHandler,
+  Next,
+  ErrorHandler,
+  ValidationTargets,
+} from "./types";
 
 /**
  * Type for context.

--- a/packages/core/src/request.ts
+++ b/packages/core/src/request.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { getPath, getQueryParam } from "./utils/url";
-import type { ParamKeys, ParamsToRecord } from "./types";
+import type { ParamKeys, ParamsToRecord, ValidationTargets } from "./types";
 import type { CustomHeader, RequestHeader } from "./utils/headers";
 
 type Body = {
@@ -17,11 +17,13 @@ export class SpectraRequest<P extends string = "/"> {
 
   #params: ParamsToRecord<ParamKeys<P>>;
   #body: Body = {};
+  #validData: { [K in keyof ValidationTargets]?: unknown };
 
   constructor(request: Request, params: ParamsToRecord<ParamKeys<P>>) {
     this.raw = request;
     this.path = getPath(request);
     this.#params = params;
+    this.#validData = {};
   }
 
   param<K extends ParamKeys<P>>(key: K): string {
@@ -56,6 +58,14 @@ export class SpectraRequest<P extends string = "/"> {
       headers[k] = v;
     });
     return headers;
+  }
+
+  setValidData(target: keyof ValidationTargets, data: unknown): void {
+    this.#validData[target] = data;
+  }
+
+  valid<T>(target: keyof ValidationTargets): T {
+    return this.#validData[target] as T;
   }
 
   async #parseBody(key: keyof Body) {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -2,6 +2,7 @@
 /* eslint-disable @typescript-eslint/no-invalid-void-type */
 import type { Context } from "./context";
 import type { Spectra } from "./spectra";
+import type { CustomHeader, RequestHeader } from "./utils/headers";
 
 ///////////////////////////////////////
 ////                               ////
@@ -241,3 +242,17 @@ export interface RouteInterface<BasePath extends string = "/"> {
     ]
   ): Spectra<BasePath>;
 }
+
+///////////////////////////////////////
+////                               ////
+////          Validation           ////
+////                               ////
+///////////////////////////////////////
+
+export type ValidationTargets = {
+  json: any;
+  form: Record<string, string | File | (string | File)[]>;
+  query: Record<string, string | string[]>;
+  params: Record<string, string>;
+  headers: Record<RequestHeader | CustomHeader, string>;
+};

--- a/packages/core/src/validator.test.ts
+++ b/packages/core/src/validator.test.ts
@@ -14,7 +14,7 @@ describe("JSON", () => {
       return { name };
     }),
     (c) => {
-      const { name } = c.get("valid") as { name: string };
+      const { name } = c.req.valid<{ name: string }>("json");
       return c.json({ message: `Hi ${name}!` });
     }
   );
@@ -66,7 +66,7 @@ describe("Malformed JSON request", () => {
     "/post",
     validator("json", (value) => value),
     (c) => {
-      return c.json(c.get("valid"));
+      return c.json(c.req.valid("json"));
     }
   );
 
@@ -90,7 +90,7 @@ describe("FormData", () => {
     "/greet",
     validator("form", (value) => value),
     (c) => {
-      return c.json(c.get("valid"));
+      return c.json(c.req.valid("form"));
     }
   );
 
@@ -130,7 +130,7 @@ describe("Malformed FormData request", () => {
     "/post",
     validator("form", (value) => value),
     (c) => {
-      return c.json(c.get("valid"));
+      return c.json(c.req.valid("form"));
     }
   );
 
@@ -160,7 +160,7 @@ describe("Query", () => {
       return { q };
     }),
     (c) => {
-      const { q } = c.get("valid") as { q: string };
+      const { q } = c.req.valid<{ q: string }>("query");
       return c.text(q);
     }
   );
@@ -189,7 +189,7 @@ describe("Params", () => {
       return { id };
     }),
     (c) => {
-      const { id } = c.get("valid") as { id: string };
+      const { id } = c.req.valid<{ id: string }>("params");
       return c.text(id);
     }
   );
@@ -218,7 +218,7 @@ describe("Headers", () => {
       return { reqId };
     }),
     (c) => {
-      const { reqId } = c.get("valid") as { reqId: string };
+      const { reqId } = c.req.valid<{ reqId: string }>("headers");
       return c.text(reqId);
     }
   );

--- a/packages/core/src/validator.ts
+++ b/packages/core/src/validator.ts
@@ -1,15 +1,5 @@
 import type { Context } from "./context";
-import type { MiddlewareHandler } from "./types";
-import type { CustomHeader, RequestHeader } from "./utils/headers";
-
-export type ValidationTargets = {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  json: any;
-  form: Record<string, string | File | (string | File)[]>;
-  query: Record<string, string | string[]>;
-  params: Record<string, string>;
-  headers: Record<RequestHeader | CustomHeader, string>;
-};
+import type { MiddlewareHandler, ValidationTargets } from "./types";
 
 export type ValidationFunction<I, O> = (
   value: I,
@@ -23,7 +13,6 @@ export const validator = <U extends keyof ValidationTargets, O>(
   return async function (c, next) {
     let value;
 
-    // TODO: check content-type for json and form targets
     switch (target) {
       case "json":
         try {
@@ -72,7 +61,7 @@ export const validator = <U extends keyof ValidationTargets, O>(
       return res;
     }
 
-    c.set("valid", res);
+    c.req.setValidData(target, res);
     await next();
   };
 };

--- a/packages/zod/README.md
+++ b/packages/zod/README.md
@@ -34,7 +34,7 @@ const schema = z.object({
 });
 
 app.post("/post", zodValidator("json", schema), async (c) => {
-  const { name, age } = c.get<z.infer<typeof schema>>("valid");
+  const { name, age } = c.req.valid<z.infer<typeof schema>>("json");
   return c.json({ name, age });
 });
 

--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -1,5 +1,5 @@
-import type { MiddlewareHandler } from "@spectrajs/core";
-import { validator, type ValidationTargets } from "@spectrajs/core/validator";
+import type { MiddlewareHandler, ValidationTargets } from "@spectrajs/core";
+import { validator } from "@spectrajs/core/validator";
 import { ZodObject, type ZodSchema } from "zod";
 
 export const zodValidator = <

--- a/packages/zod/test/index.test.ts
+++ b/packages/zod/test/index.test.ts
@@ -12,7 +12,7 @@ describe("Basic", () => {
   });
 
   app.post("/greet", zodValidator("json", schema), (c) => {
-    const { name, age } = c.get<z.infer<typeof schema>>("valid");
+    const { name, age } = c.req.valid<z.infer<typeof schema>>("json");
     return c.json({ name, age });
   });
 
@@ -69,7 +69,7 @@ describe("Headers", () => {
   });
 
   app.get("/user", zodValidator("headers", schema), (c) => {
-    const { authorization } = c.get<z.infer<typeof schema>>("valid");
+    const { authorization } = c.req.valid<z.infer<typeof schema>>("headers");
     return c.json({ authorization });
   });
 


### PR DESCRIPTION
This PR introduces a new, more explicit way to access validated data through `c.req.valid(target)`.

### Changes

- **New Interface:** `c.get("valid")` moved to `c.req.valid(target)`.
- **Type Migration:** `ValidationTargets` type moved from `@spectrajs/core/validator` to `@spectrajs/core`.

### Migration Guide

```diff
- const { name } = c.get<{ name: string }>("valid");
+ const { name } = c.req.valid<{ name: string }>("json");
```