### PR TITLE
feat(arktype): introduce @spectrajs/arktype package

### DIFF
--- a/.changeset/proud-bees-relax.md
+++ b/.changeset/proud-bees-relax.md
@@ -1,0 +1,5 @@
+---
+"@spectrajs/arktype": minor
+---
+
+Added ArkType validator.

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ The documentation is available [here](docs/index.md).
 - [@spectrajs/trpc](https://www.npmjs.com/package/@spectrajs/trpc)
 - [@spectrajs/swagger](https://www.npmjs.com/package/@spectrajs/swagger)
 - [@spectrajs/zod](https://www.npmjs.com/package/@spectrajs/zod)
+- [@spectrajs/arktype](https://www.npmjs.com/package/@spectrajs/arktype)
 
 ## Author
 

--- a/docs/guides/validation.md
+++ b/docs/guides/validation.md
@@ -80,3 +80,39 @@ app.post("/post", zodValidator("json", schema), async (c) => {
   return c.json({ name, age });
 });
 ```
+
+### ArkType Validator
+
+The ArkType Validator is a middleware that uses [ArkType](https://arktype.io) to
+validate incoming data. It uses [Core Validator](#core-validator) under the hood.
+
+Start by installing `arktype` and `@spectrajs/arktype`:
+
+```sh
+npm install arktype @spectrajs/arktype
+```
+
+Import `arktypeValidator` from `@spectrajs/arktype` and `type` from `arktype`:
+
+```ts
+import { arktypeValidator } from "@spectrajs/arktype";
+import { type } from "arktype";
+```
+
+Then, define your schema:
+
+```ts
+const User = type({
+  name: "string",
+  age: "number",
+});
+```
+
+Finally, use `arktypeValidator` to validate incoming data:
+
+```ts
+app.post("/post", arktypeValidator("json", User), async (c) => {
+  const { name, age } = c.req.valid<typeof User.infer>("json");
+  return c.json({ name, age });
+});
+```

--- a/packages/arktype/README.md
+++ b/packages/arktype/README.md
@@ -1,0 +1,46 @@
+# @spectrajs/arktype
+
+[![codecov](https://codecov.io/gh/metebykl/spectra/graph/badge.svg)](https://codecov.io/gh/metebykl/spectra)
+[![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/metebykl/spectra/ci.yml?branch=main)](https://github.com/metebykl/spectra/actions)
+[![License](https://img.shields.io/github/license/metebykl/spectra)](https://github.com/metebykl/spectra/blob/main/LICENSE)
+[![npm](https://img.shields.io/npm/v/@spectrajs/arktype.svg)](https://www.npmjs.com/package/@spectrajs/arktype)
+[![npm](https://img.shields.io/npm/d18m/@spectrajs/arktype.svg)](https://www.npmjs.com/package/@spectrajs/arktype)
+[![Bundle Size](https://img.shields.io/bundlephobia/min/@spectrajs/arktype)](https://bundlephobia.com/result?p=@spectrajs/arktype)
+
+A validator middleware using [ArkType](https://arktype.io) for Spectra.
+
+## Installation
+
+```sh
+npm install @spectrajs/arktype
+```
+
+## Documentation
+
+The documentation is available [here](../../docs/guides/validation.md#arktype-validator).
+
+## Usage
+
+```ts
+import { Spectra } from "@spectrajs/core";
+import { type } from "arktype";
+import { arktypeValidator } from "@spectrajs/arktype";
+
+const app = new Spectra();
+
+const User = type({
+  name: "string",
+  age: "number",
+});
+
+app.post("/post", arktypeValidator("json", User), async (c) => {
+  const { name, age } = c.req.valid<typeof User.infer>("json");
+  return c.json({ name, age });
+});
+
+export default app;
+```
+
+## License
+
+Distributed under the MIT License. See [LICENSE](LICENSE) for more information.

--- a/packages/arktype/package.json
+++ b/packages/arktype/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "@spectrajs/arktype",
+  "version": "0.13.0",
+  "description": "ArkType Validator for Spectra",
+  "main": "./dist/index.cjs",
+  "type": "module",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "scripts": {
+    "build": "tsup",
+    "lint": "eslint src",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/metebykl/spectra.git"
+  },
+  "keywords": [
+    "web",
+    "http",
+    "framework",
+    "adapter"
+  ],
+  "author": "metebykl",
+  "license": "MIT",
+  "homepage": "https://github.com/metebykl/spectra#readme",
+  "files": [
+    "dist"
+  ],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "peerDependencies": {
+    "@spectrajs/core": ">= 0.12.1",
+    "arktype": "^2.1.19"
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.15.0",
+    "@spectrajs/core": "workspace:*",
+    "@types/node": "^22.10.2",
+    "arktype": "^2.1.19",
+    "eslint": "^9.15.0",
+    "prettier": "^3.3.3",
+    "tsup": "^8.3.5",
+    "typescript": "^5.6.3"
+  }
+}

--- a/packages/arktype/src/index.ts
+++ b/packages/arktype/src/index.ts
@@ -1,0 +1,34 @@
+import type { MiddlewareHandler, ValidationTargets } from "@spectrajs/core";
+import { validator } from "@spectrajs/core/validator";
+import { type, type Type } from "arktype";
+
+export const arktypeValidator = <
+  U extends keyof ValidationTargets,
+  Z extends Type,
+>(
+  target: U,
+  schema: Z
+): MiddlewareHandler => {
+  return validator(target, async (value, c) => {
+    let data = value;
+
+    if (target === "headers") {
+      const keys = Object.keys(schema);
+      const keyMap = new Map(keys.map((k) => [k.toLowerCase(), k]));
+
+      data = Object.fromEntries(
+        Object.entries(value).map(([k, v]) => [
+          keyMap.get(k.toLowerCase()) || k,
+          v,
+        ])
+      );
+    }
+
+    const out = schema(data);
+    if (out instanceof type.errors) {
+      return c.json({ success: false, error: out }, 400);
+    }
+
+    return out;
+  });
+};

--- a/packages/arktype/test/index.test.ts
+++ b/packages/arktype/test/index.test.ts
@@ -1,0 +1,101 @@
+import { describe, test, expect } from "vitest";
+import { Spectra } from "@spectrajs/core";
+import { type } from "arktype";
+import { arktypeValidator } from "../src";
+
+describe("Basic", () => {
+  const app = new Spectra();
+
+  const User = type({
+    name: "3 <= string <= 10",
+    age: "number",
+  });
+
+  app.post("/greet", arktypeValidator("json", User), (c) => {
+    const { name, age } = c.req.valid<typeof User.infer>("json");
+    return c.json({ name, age });
+  });
+
+  test("Should return response 200", async () => {
+    const res = await app.fetch(
+      new Request("http://localhost/greet", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ name: "Spectra", age: 20 }),
+      })
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ name: "Spectra", age: 20 });
+  });
+
+  test("Should return response 400", async () => {
+    const res = await app.fetch(
+      new Request("http://localhost/greet", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ name: "ab", age: 20 }),
+      })
+    );
+    expect(res.status).toBe(400);
+    const data = (await res.json()) as { success: boolean };
+    expect(data.success).toBe(false);
+  });
+
+  test("Should return response 400", async () => {
+    const res = await app.fetch(
+      new Request("http://localhost/greet", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ name: "Spectra", age: "20" }),
+      })
+    );
+    expect(res.status).toBe(400);
+    const data = (await res.json()) as { success: boolean };
+    expect(data.success).toBe(false);
+  });
+});
+
+describe("Headers", () => {
+  const app = new Spectra();
+
+  const Schema = type({
+    authorization: /^Bearer\s.+$/,
+  });
+
+  app.get("/user", arktypeValidator("headers", Schema), (c) => {
+    const { authorization } = c.req.valid<typeof Schema.infer>("headers");
+    return c.json({ authorization });
+  });
+
+  test("Should return response 200", async () => {
+    const res = await app.fetch(
+      new Request("http://localhost/user", {
+        headers: { Authorization: "Bearer abc" },
+      })
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ authorization: "Bearer abc" });
+  });
+
+  test("Should return response 400", async () => {
+    let res = await app.fetch(
+      new Request("http://localhost/user", {
+        headers: { Authorization: "abc" },
+      })
+    );
+    expect(res.status).toBe(400);
+    let data = (await res.json()) as { success: boolean };
+    expect(data.success).toBe(false);
+
+    res = await app.fetch(new Request("http://localhost/user"));
+    expect(res.status).toBe(400);
+    data = (await res.json()) as { success: boolean };
+    expect(data.success).toBe(false);
+  });
+});

--- a/packages/arktype/tsconfig.json
+++ b/packages/arktype/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src", "test"]
+}

--- a/packages/arktype/tsup.config.ts
+++ b/packages/arktype/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm", "cjs"],
+  dts: true,
+  splitting: false,
+  sourcemap: false,
+  bundle: true,
+  clean: true,
+});

--- a/packages/arktype/vitest.config.ts
+++ b/packages/arktype/vitest.config.ts
@@ -1,0 +1,1 @@
+export { default } from "../../vitest.config";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,33 @@ importers:
         specifier: ^2.1.9
         version: 2.1.9(@types/node@22.13.9)
 
+  packages/arktype:
+    devDependencies:
+      '@eslint/js':
+        specifier: ^9.15.0
+        version: 9.23.0
+      '@spectrajs/core':
+        specifier: workspace:*
+        version: link:../core
+      '@types/node':
+        specifier: ^22.10.2
+        version: 22.13.9
+      arktype:
+        specifier: ^2.1.19
+        version: 2.1.19
+      eslint:
+        specifier: ^9.15.0
+        version: 9.21.0
+      prettier:
+        specifier: ^3.3.3
+        version: 3.5.3
+      tsup:
+        specifier: ^8.3.5
+        version: 8.4.0(postcss@8.5.3)(typescript@5.8.2)
+      typescript:
+        specifier: ^5.6.3
+        version: 5.8.2
+
   packages/core:
     devDependencies:
       '@eslint/js':
@@ -170,6 +197,12 @@ packages:
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
+
+  '@ark/schema@0.45.9':
+    resolution: {integrity: sha512-rG0v/JI0sibn/0wERAHTYVLCtEqoMP2IIlxnb+S5DrEjCI5wpubbZSWMDW50tZ8tV6FANu6zzHDeeKbp6lsZdg==}
+
+  '@ark/util@0.45.9':
+    resolution: {integrity: sha512-0WYNAb8aRGp7dNt6xIvIrRzL7V1XL3u3PK2vcklhtTrdaP235DjC9qJhzidrxtWr68mA5ySSjUrgrXk622bKkw==}
 
   '@babel/helper-string-parser@7.25.9':
     resolution: {integrity: sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==}
@@ -1001,6 +1034,9 @@ packages:
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  arktype@2.1.19:
+    resolution: {integrity: sha512-notORSuTSpfLV7rq0kYC4mTgIVlVR0xQuvtFxOaE9aKiXyON/kgoIBwZZcKeSSb4BebNcfJoGlxJicAUl/HMdw==}
 
   array-union@2.1.0:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
@@ -2127,6 +2163,12 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.8
       '@jridgewell/trace-mapping': 0.3.25
 
+  '@ark/schema@0.45.9':
+    dependencies:
+      '@ark/util': 0.45.9
+
+  '@ark/util@0.45.9': {}
+
   '@babel/helper-string-parser@7.25.9': {}
 
   '@babel/helper-validator-identifier@7.25.9': {}
@@ -2867,6 +2909,11 @@ snapshots:
       sprintf-js: 1.0.3
 
   argparse@2.0.1: {}
+
+  arktype@2.1.19:
+    dependencies:
+      '@ark/schema': 0.45.9
+      '@ark/util': 0.45.9
 
   array-union@2.1.0: {}
 


### PR DESCRIPTION
### @spectrajs/arktype

This PR introduces a validator middleware using [ArkType](https://arktype.io) for Spectra.

```ts
const User = type({
  name: "string",
  age: "number",
});

app.post("/post", arktypeValidator("json", User), async (c) => {
  const { name, age } = c.req.valid<typeof User.infer>("json");
  return c.json({ name, age });
});
```